### PR TITLE
add compile scope for org.jboss.weld.se

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,6 +179,12 @@
         <groupId>javax.enterprise</groupId>
         <artifactId>cdi-api</artifactId>
         <version>1.1</version>
+        <scope>compile</scope>
+      </dependency>
+      <dependency>
+        <groupId>javax.enterprise</groupId>
+        <artifactId>cdi-api</artifactId>
+        <version>1.1</version>
         <scope>provided</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,19 @@
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>jaxrs-api</artifactId>
         <version>2.2.0.GA</version>
+        <scope>compile</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.resteasy</groupId>
+        <artifactId>jaxrs-api</artifactId>
+        <version>2.2.0.GA</version>
         <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.resteasy</groupId>
+        <artifactId>resteasy-jaxrs</artifactId>
+        <version>2.2.0.GA</version>
+        <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>org.jboss.resteasy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -174,6 +174,12 @@
         <groupId>javax.inject</groupId>
         <artifactId>javax.inject</artifactId>
         <version>1</version>
+        <scope>compile</scope>
+      </dependency>
+      <dependency>
+        <groupId>javax.inject</groupId>
+        <artifactId>javax.inject</artifactId>
+        <version>1</version>
         <scope>provided</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
     <jackson-version>2.4.1</jackson-version>
     <httpclient-version>4.4</httpclient-version>
     <version.org.jboss.weld.se>2.3.2.Final</version.org.jboss.weld.se>
+    <version.javax.enterprise.cdi-api>1.1</version.javax.enterprise.cdi-api>
   </properties>
   
   <dependencyManagement>
@@ -178,13 +179,13 @@
       <dependency>
         <groupId>javax.enterprise</groupId>
         <artifactId>cdi-api</artifactId>
-        <version>1.1</version>
+        <version>${version.javax.enterprise.cdi-api}</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>javax.enterprise</groupId>
         <artifactId>cdi-api</artifactId>
-        <version>1.1</version>
+        <version>${version.javax.enterprise.cdi-api}</version>
         <scope>provided</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -286,6 +286,18 @@
       
       <dependency>
         <groupId>org.jboss.weld.se</groupId>
+        <artifactId>weld-se</artifactId>
+        <version>${version.org.jboss.weld.se}</version>
+        <scope>compile</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.weld.se</groupId>
+        <artifactId>weld-se</artifactId>
+        <version>${version.org.jboss.weld.se}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.weld.se</groupId>
         <artifactId>weld-se-core</artifactId>
         <version>${version.org.jboss.weld.se}</version>
         <scope>compile</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -190,6 +190,18 @@
         <scope>provided</scope>
       </dependency>
       <dependency>
+        <groupId>org.jboss.resteasy</groupId>
+        <artifactId>async-http-servlet-3.0</artifactId>
+        <version>${version.org.jboss.resteasy}</version>
+        <scope>compile</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.resteasy</groupId>
+        <artifactId>async-http-servlet-3.0</artifactId>
+        <version>${version.org.jboss.resteasy}</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
         <groupId>org.jboss.spec.javax.servlet</groupId>
         <artifactId>jboss-servlet-api_3.0_spec</artifactId>
         <version>1.0.0.Final</version>

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
     <webdav-version>3.2.0</webdav-version>
     <jackson-version>2.4.1</jackson-version>
     <httpclient-version>4.4</httpclient-version>
+    <version.org.jboss.resteasy>2.2.0.GA</version.org.jboss.resteasy>
     <version.org.jboss.weld.se>2.3.2.Final</version.org.jboss.weld.se>
     <version.javax.enterprise.cdi-api>1.2</version.javax.enterprise.cdi-api>
   </properties>
@@ -155,25 +156,25 @@
       <dependency>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>jaxrs-api</artifactId>
-        <version>2.2.0.GA</version>
+        <version>${version.org.jboss.resteasy}</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>jaxrs-api</artifactId>
-        <version>2.2.0.GA</version>
+        <version>${version.org.jboss.resteasy}</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs</artifactId>
-        <version>2.2.0.GA</version>
+        <version>${version.org.jboss.resteasy}</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs</artifactId>
-        <version>2.2.0.GA</version>
+        <version>${version.org.jboss.resteasy}</version>
         <scope>provided</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
     <webdav-version>3.2.0</webdav-version>
     <jackson-version>2.4.1</jackson-version>
     <httpclient-version>4.4</httpclient-version>
+    <version.org.jboss.weld.se>2.1.1.Final</version.org.jboss.weld.se>
   </properties>
   
   <dependencyManagement>
@@ -224,13 +225,13 @@
       <dependency>
         <groupId>org.jboss.weld.se</groupId>
         <artifactId>weld-se-core</artifactId>
-        <version>2.1.1.Final</version>
+        <version>${version.org.jboss.weld.se}</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>org.jboss.weld.se</groupId>
         <artifactId>weld-se-core</artifactId>
-        <version>2.1.1.Final</version>
+        <version>${version.org.jboss.weld.se}</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <webdav-version>3.2.0</webdav-version>
     <jackson-version>2.4.1</jackson-version>
     <httpclient-version>4.4</httpclient-version>
-    <version.org.jboss.weld.se>2.1.1.Final</version.org.jboss.weld.se>
+    <version.org.jboss.weld.se>2.3.2.Final</version.org.jboss.weld.se>
   </properties>
   
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -225,6 +225,12 @@
         <groupId>org.jboss.weld.se</groupId>
         <artifactId>weld-se-core</artifactId>
         <version>2.1.1.Final</version>
+        <scope>compile</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.weld.se</groupId>
+        <artifactId>weld-se-core</artifactId>
+        <version>2.1.1.Final</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <webdav-version>3.2.0</webdav-version>
     <jackson-version>2.4.1</jackson-version>
     <httpclient-version>4.4</httpclient-version>
-    <version.org.jboss.resteasy>2.2.0.GA</version.org.jboss.resteasy>
+    <version.org.jboss.resteasy>3.0.12.Final</version.org.jboss.resteasy>
     <version.org.jboss.weld.se>2.3.2.Final</version.org.jboss.weld.se>
     <version.javax.enterprise.cdi-api>1.2</version.javax.enterprise.cdi-api>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <jackson-version>2.4.1</jackson-version>
     <httpclient-version>4.4</httpclient-version>
     <version.org.jboss.weld.se>2.3.2.Final</version.org.jboss.weld.se>
-    <version.javax.enterprise.cdi-api>1.1</version.javax.enterprise.cdi-api>
+    <version.javax.enterprise.cdi-api>1.2</version.javax.enterprise.cdi-api>
   </properties>
   
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -179,6 +179,18 @@
       </dependency>
       <dependency>
         <groupId>org.jboss.resteasy</groupId>
+        <artifactId>resteasy-cdi</artifactId>
+        <version>${version.org.jboss.resteasy}</version>
+        <scope>compile</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.resteasy</groupId>
+        <artifactId>resteasy-cdi</artifactId>
+        <version>${version.org.jboss.resteasy}</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs</artifactId>
         <version>${version.org.jboss.resteasy}</version>
         <scope>compile</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -167,6 +167,18 @@
       </dependency>
       <dependency>
         <groupId>org.jboss.resteasy</groupId>
+        <artifactId>jaxrs-cdi</artifactId>
+        <version>${version.org.jboss.resteasy}</version>
+        <scope>compile</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.resteasy</groupId>
+        <artifactId>jaxrs-cdi</artifactId>
+        <version>${version.org.jboss.resteasy}</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs</artifactId>
         <version>${version.org.jboss.resteasy}</version>
         <scope>compile</scope>


### PR DESCRIPTION
without that children get test scope even in case when compile is required
eg. causeway launcher is created without weld because the weld dependency is resolved with test scope based on single scope defined in bom
